### PR TITLE
Exchange currency of price range 

### DIFF
--- a/django_prices_openexchangerates/__init__.py
+++ b/django_prices_openexchangerates/__init__.py
@@ -4,7 +4,7 @@ import operator
 from decimal import Decimal
 
 from django.conf import settings
-from prices import History, Price, PriceModifier
+from prices import History, Price, PriceModifier, PriceRange
 
 from .models import ConversionRate
 
@@ -65,6 +65,10 @@ def convert_price(price, to_currency):
 
 
 def exchange_currency(price, to_currency):
+    if isinstance(price, PriceRange):
+        return PriceRange(
+            exchange_currency(price.min_price, to_currency),
+            exchange_currency(price.max_price, to_currency))
     if price.currency != BASE_CURRENCY:
         # Convert to default currency
         price = convert_price(price, BASE_CURRENCY)

--- a/django_prices_openexchangerates/__init__.py
+++ b/django_prices_openexchangerates/__init__.py
@@ -72,4 +72,4 @@ def exchange_currency(price, to_currency):
     if price.currency != BASE_CURRENCY:
         # Convert to default currency
         price = convert_price(price, BASE_CURRENCY)
-    return convert_price(price, to_currency)
+    return convert_price(price, to_currency).quantize(CENTS)

--- a/django_prices_openexchangerates/__init__.py
+++ b/django_prices_openexchangerates/__init__.py
@@ -72,4 +72,4 @@ def exchange_currency(price, to_currency):
     if price.currency != BASE_CURRENCY:
         # Convert to default currency
         price = convert_price(price, BASE_CURRENCY)
-    return convert_price(price, to_currency).quantize(CENTS)
+    return convert_price(price, to_currency)


### PR DESCRIPTION
This PR adds ability to exchange currency of price range:
```
>>> range = PriceRange(Price('25', currency='USD'), Price('100', currency='USD'))
>>> exchange_currency(range, 'EUR')
PriceRange(Price('22.87650', currency='EUR'), Price('91.50600', currency='EUR'))
```
 