### PR TITLE
Use base currency instead of default

### DIFF
--- a/django_prices_openexchangerates/models.py
+++ b/django_prices_openexchangerates/models.py
@@ -3,11 +3,11 @@ from __future__ import unicode_literals
 from decimal import Decimal
 from threading import local
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
-from django.conf import settings
 
 from .currencies import CURRENCIES
 

--- a/django_prices_openexchangerates/tasks.py
+++ b/django_prices_openexchangerates/tasks.py
@@ -19,7 +19,7 @@ except AttributeError:
 
 
 def extract_rate(rates, currency):
-    base_rate = rates[settings.DEFAULT_CURRENCY]
+    base_rate = rates[BASE_CURRENCY]
     return rates[currency] / base_rate
 
 


### PR DESCRIPTION
This PR fixes conversion rates of `USD` currency.

Assuming that the default currency  is `AED`, conversion returs:
```
1 USD = 1.0000 AED
...
```
and therefore:
```
>>> exchange_currency(Price('100', currency='AED'), 'EUR')
Price('24.91500', currency='EUR')
>>> exchange_currency(Price('100', currency='USD'), 'EUR')
Price('24.91500', currency='EUR')
```
An example of correct exchange currency:
```
>>> exchange_currency(Price('100', currency='AED'), 'EUR')
Price('24.89239070952706363445784248', currency='EUR')
>>> exchange_currency(Price('100', currency='USD'), 'EUR')
Price('91.43000', currency='EUR')
```