### PR TITLE
Use django caching mechanism instead of thread locals

### DIFF
--- a/django_prices_openexchangerates/models.py
+++ b/django_prices_openexchangerates/models.py
@@ -12,13 +12,14 @@ from django.utils.encoding import python_2_unicode_compatible
 from .currencies import CURRENCIES
 
 BASE_CURRENCY = getattr(settings, 'OPENEXCHANGERATES_BASE_CURRENCY', 'USD')
-CACHE_KEY = getattr(settings, 'OPENEXCHANGERATES_CACHE_KEY', 'conversion_rates')
+CACHE_KEY = getattr(settings, 'OPENEXCHANGERATES_CACHE_KEY',
+                    'openexchangerates_conversion_rates')
 CACHE_TIME = getattr(settings, 'OPENEXCHANGERATES_CACHE_TTL', 60*60)
 
 
-def get_rates(qs):
+def get_rates(qs, force_refresh=False):
     conversion_rates = cache.get(CACHE_KEY)
-    if not conversion_rates:
+    if not conversion_rates or force_refresh:
         conversion_rates = {rate.to_currency: rate for rate in qs}
         cache.set(CACHE_KEY, conversion_rates, CACHE_TIME)
     return conversion_rates

--- a/django_prices_openexchangerates/tasks.py
+++ b/django_prices_openexchangerates/tasks.py
@@ -8,7 +8,7 @@ import logging
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from .models import ConversionRate
+from .models import ConversionRate, get_rates
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,7 @@ def update_conversion_rates():
                                          conversion_rate.to_currency)
         conversion_rate.rate = new_exchange_rate
         conversion_rate.save(update_fields=['rate'])
+    get_rates(ConversionRate.objects.all(), force_refresh=True)
     return conversion_rates
 
 


### PR DESCRIPTION
We shouldn't rely on thread locals. There is no way to void cached items without restarting a process.