### PR TITLE
Sort currency choices to shut up Django migration change detection

### DIFF
--- a/django_prices_openexchangerates/models.py
+++ b/django_prices_openexchangerates/models.py
@@ -43,7 +43,7 @@ class ConversionRate(models.Model):
 
     to_currency = models.CharField(
         _('To'), max_length=3, db_index=True,
-        choices=CURRENCIES.items(), unique=True)
+        choices=sorted(CURRENCIES.items(), key=lambda x: x[0]), unique=True)
 
     rate = models.DecimalField(
         _('Conversion rate'), max_digits=20, decimal_places=12)


### PR DESCRIPTION
I had problems migrating my own models in Saleor due to Django constantly detecting changes in the currency choices.