### PR TITLE
fix  github project name in setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description='openexchangerates.org support for django-prices',
     license='BSD',
     version='0.1.13',
-    url='https://github.com/mirumee/django-prices-openexchanerates',
+    url='https://github.com/mirumee/django-prices-openexchangerates',
     packages=[
         'django_prices_openexchangerates',
         'django_prices_openexchangerates.management',


### PR DESCRIPTION
s/django-prices-openexchanerates/django-prices-openexchangerates/

It's only a tiny typo, but it breaks the link from PyPI to the project's repository...

Thanks for sharing your code!