### PR TITLE
Allow to pass all_rates to exchange_currency

### DIFF
--- a/django_prices_openexchangerates/__init__.py
+++ b/django_prices_openexchangerates/__init__.py
@@ -35,9 +35,23 @@ class CurrencyConversion(PriceModifier):
                      currency=self.to_currency, history=history)
 
 
-def convert_price(price, to_currency, all_rates=None):
+def get_conversion_rate(currency):
+    """
+    Fetch currency conversion rate from the database
+    """
     from .models import ConversionRate
+    try:
+        rate = ConversionRate.objects.get_rate(currency)
+    except ConversionRate.DoesNotExist:  # noqa
+        raise ValueError('No conversion rate for %s' % (currency, ))
+    return rate.rate
 
+
+def convert_price(price, to_currency, get_rate=get_conversion_rate):
+    """
+    Converts Price object to specified currency.
+    get_rate parameter is a callable that returns proper conversion rate
+    """
     if price.currency == to_currency:
         return price
     reverse_rate = False
@@ -48,22 +62,12 @@ def convert_price(price, to_currency, all_rates=None):
         reverse_rate = True
     else:
         rate_currency = to_currency
-    if all_rates is None:
-        try:
-            rate = ConversionRate.objects.get_rate(rate_currency)
-        except ConversionRate.DoesNotExist:  # noqa
-            raise ValueError('No conversion rate for %s' % (rate_currency, ))
-    else:
-        try:
-            rate = all_rates[rate_currency]
-        except KeyError:
-            raise ValueError('No conversion rate for %s found in rates dict' % (
-                rate_currency,))
+    rate = get_rate(rate_currency)
 
     if reverse_rate:
-        conversion_rate = 1 / rate.rate
+        conversion_rate = 1 / rate
     else:
-        conversion_rate = rate.rate
+        conversion_rate = rate
     conversion = CurrencyConversion(
         base_currency=price.currency,
         to_currency=to_currency,
@@ -71,12 +75,15 @@ def convert_price(price, to_currency, all_rates=None):
     return conversion.apply(price)
 
 
-def exchange_currency(price, to_currency, all_rates=None):
+def exchange_currency(price, to_currency, get_rate=get_conversion_rate):
+    """
+    Exchanges Price or PriceRange to the specified currency
+    """
     if isinstance(price, PriceRange):
         return PriceRange(
             exchange_currency(price.min_price, to_currency),
             exchange_currency(price.max_price, to_currency))
     if price.currency != BASE_CURRENCY:
         # Convert to default currency
-        price = convert_price(price, BASE_CURRENCY, all_rates=all_rates)
-    return convert_price(price, to_currency, all_rates=all_rates)
+        price = convert_price(price, BASE_CURRENCY, get_rate=get_rate)
+    return convert_price(price, to_currency, get_rate=get_rate)

--- a/django_prices_openexchangerates/tests.py
+++ b/django_prices_openexchangerates/tests.py
@@ -69,15 +69,14 @@ class CurrencyConversionTestCase(TestCase):
 
     def test_convert_price_uses_passed_dict(self, mock_qs):
         base_price = Price(10, currency='USD')
-        all_rates = {'GBP': mock_rates('GBP')}
-        converted_price = exchange_currency(
-            base_price, 'GBP', all_rates=all_rates)
-        self.assertFalse(mock_qs.called)
-        self.assertEqual(converted_price.currency, 'GBP')
 
-    def test_convert_price_uses_db_when_dict_not_passed(self, mock_qs):
-        base_price = Price(10, currency='EUR')
-        converted_price = exchange_currency(base_price, 'GBP', all_rates=None)
+        def custom_get_rate(currency):
+            data = {'GBP': Decimal(5)}
+            return data[currency]
+
+        converted_price = exchange_currency(
+            base_price, 'GBP', get_rate=custom_get_rate)
+        self.assertFalse(mock_qs.called)
         self.assertEqual(converted_price.currency, 'GBP')
 
 

--- a/django_prices_openexchangerates/tests.py
+++ b/django_prices_openexchangerates/tests.py
@@ -67,6 +67,19 @@ class CurrencyConversionTestCase(TestCase):
         self.assertEqual(second_operation.base_currency, 'USD')
         self.assertEqual(second_operation.to_currency, 'GBP')
 
+    def test_convert_price_uses_passed_dict(self, mock_qs):
+        base_price = Price(10, currency='USD')
+        all_rates = {'GBP': mock_rates('GBP')}
+        converted_price = exchange_currency(
+            base_price, 'GBP', all_rates=all_rates)
+        self.assertFalse(mock_qs.called)
+        self.assertEqual(converted_price.currency, 'GBP')
+
+    def test_convert_price_uses_db_when_dict_not_passed(self, mock_qs):
+        base_price = Price(10, currency='EUR')
+        converted_price = exchange_currency(base_price, 'GBP', all_rates=None)
+        self.assertEqual(converted_price.currency, 'GBP')
+
 
 @mock.patch('django_prices_openexchangerates.models.ConversionRate.objects.get_rate',
             side_effect=mock_rates)
@@ -86,6 +99,14 @@ class CurrencyConversionWithAnotherBaseCurrencyTestCase(CurrencyConversionTestCa
 
     @override_settings(OPENEXCHANGERATES_BASE_CURRENCY='BTC')
     def test_convert_two_non_base_currencies(self, mock_qs):
+        pass
+
+    @override_settings(OPENEXCHANGERATES_BASE_CURRENCY='BTC')
+    def test_convert_price_uses_passed_dict(self, mock_qs):
+        pass
+
+    @override_settings(OPENEXCHANGERATES_BASE_CURRENCY='BTC')
+    def test_convert_price_uses_db_when_dict_not_passed(self, mock_qs):
         pass
 
 


### PR DESCRIPTION
When rates dictionary is passed, it's possible to avoid extra cache/db queries when converting currency for lists of items.