### PR TITLE
Fix readme and modified_at not updating by update_conversion_rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ print(converted_price)
 
 The `exchange_currency` supports `Money`, `TaxedMoney`, `MoneyRange` and `TaxedMoneyRange`.
 
-Template filters can be used to convert currency and round amounts:
+Template filters can be used with `django-prices` to convert currency, round amounts and display localized amounts in templates:
 
 ```html+django
+{% load prices_i18n %}
 {% load prices_multicurrency %}
 
-<p>Price: {{ foo.price.gross|in_currency:'USD'|amount }} ({{ foo.price.net|in_currency:'USD'|amount }} + {{ foo.price|in_currency:'USD'|amount }} tax)</p>
+<p>Price: {{ foo.price.gross|in_currency:'USD'|amount }} ({{ foo.price.net|in_currency:'USD'|amount }} + {{ foo.price.tax|in_currency:'USD'|amount }} tax)</p>
 ```
 
 

--- a/django_prices_openexchangerates/tasks.py
+++ b/django_prices_openexchangerates/tasks.py
@@ -37,7 +37,7 @@ def update_conversion_rates():
         new_exchange_rate = extract_rate(
             exchange_rates, conversion_rate.to_currency)
         conversion_rate.rate = new_exchange_rate
-        conversion_rate.save(update_fields=['rate'])
+        conversion_rate.save(update_fields=['rate', 'modified_at'])
     get_rates(ConversionRate.objects.all(), force_refresh=True)
     return conversion_rates
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='hello@mirumee.com',
     description='openexchangerates.org support for django-prices',
     license='BSD',
-    version='1.0.0-beta4',
+    version='1.0.0-beta3',
     url='https://github.com/mirumee/django-prices-openexchangerates',
     packages=[
         'django_prices_openexchangerates',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='hello@mirumee.com',
     description='openexchangerates.org support for django-prices',
     license='BSD',
-    version='1.0.0-beta3',
+    version='1.0.0-beta4',
     url='https://github.com/mirumee/django-prices-openexchangerates',
     packages=[
         'django_prices_openexchangerates',


### PR DESCRIPTION
This PR fixes the bug with `modified_at` not being updated when our task updates existing conversion rates. It also fixes example in our readme to mention dependency on `django-prices` for `amount` filter to be available, as we've removed shortcut for it from this lib's beta 3 release.