### PR TITLE
WIP Reenable __repr__, add tests for str and repr methods

### DIFF
--- a/django_prices_openexchangerates/models.py
+++ b/django_prices_openexchangerates/models.py
@@ -71,7 +71,7 @@ class ConversionRate(models.Model):
         return '1 %s = %.04f %s' % (
             self.base_currency, self.rate, self.to_currency)
 
-    def __repr___(self):  # noqa
+    def __repr__(self):  # noqa
         format_template = (
             'ConversionRate(pk=%r, base_currency=%r, to_currency=%r, rate=%r)')
         return format_template % (

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='hello@mirumee.com',
     description='openexchangerates.org support for django-prices',
     license='BSD',
-    version='1.0.0',
+    version='1.0.1',
     url='https://github.com/mirumee/django-prices-openexchangerates',
     packages=[
         'django_prices_openexchangerates',

--- a/tests/test_openexchangerates.py
+++ b/tests/test_openexchangerates.py
@@ -32,6 +32,15 @@ def conversion_rates(db):
     return rates
 
 
+def test_conversionrate__str_repr(conversion_rates):
+    obj = conversion_rates[0]
+
+    assert str(obj) == '1 USD = 2.0000 EUR'
+    assert repr(obj) == (
+        "ConversionRate(pk=1, base_currency='USD', to_currency='EUR', "
+        "rate=Decimal('2'))")
+
+
 def test_the_same_currency_uses_no_conversion():
     value = Money(10, currency='EUR')
     converted_value = exchange_currency(value, 'EUR')

--- a/tests/test_openexchangerates.py
+++ b/tests/test_openexchangerates.py
@@ -33,12 +33,15 @@ def conversion_rates(db):
 
 
 def test_conversionrate__str_repr(conversion_rates):
-    obj = conversion_rates[0]
+    obj = ConversionRate.objects.get(to_currency='EUR')
 
     assert str(obj) == '1 USD = 2.0000 EUR'
-    assert repr(obj) == (
-        "ConversionRate(pk=1, base_currency='USD', to_currency='EUR', "
-        "rate=Decimal('2'))")
+
+    obj_repr = repr(obj)
+    assert 'ConversionRate' in obj_repr
+    assert 'pk={},'.format(obj.pk) in obj_repr
+    assert "base_currency='USD'," in obj_repr
+    assert "to_currency='EUR'," in obj_repr
 
 
 def test_the_same_currency_uses_no_conversion():


### PR DESCRIPTION
This PR reenables `__repr__` on `ConversionRate` model, adds assertion for `__str__` and `__repr__` outputs to catch future problems, and bumps version to 1.0.1 because this is non-breaking change.

Fixes #32 