### PR TITLE
Fix typo in tasks.py

### DIFF
--- a/django_prices_openexchangerates/management/commands/update_exchange_rates.py
+++ b/django_prices_openexchangerates/management/commands/update_exchange_rates.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from ...tasks import update_conversion_rates, create_conversion_dates
+from ...tasks import update_conversion_rates, create_conversion_rates
 
 
 class Command(BaseCommand):
@@ -15,7 +15,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if options['all_currencies']:
-            all_rates = create_conversion_dates()
+            all_rates = create_conversion_rates()
         else:
             all_rates = update_conversion_rates()
         for conversion_rate in all_rates:

--- a/django_prices_openexchangerates/tasks.py
+++ b/django_prices_openexchangerates/tasks.py
@@ -42,7 +42,7 @@ def update_conversion_rates():
     return conversion_rates
 
 
-def create_conversion_dates():
+def create_conversion_rates():
     exchange_rates = get_latest_exchange_rates()
     for currency in exchange_rates:
         if currency == BASE_CURRENCY:


### PR DESCRIPTION
Typo resolved for function _create_conversion_dates()_ to _create_conversion_rates()_ in tasks.py