### PR TITLE
Add support for Django 5 and Python 3.11, 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # openexchangerates.org support for `django-prices`
 
+## Django 5 Compatibility
+This fork of django-prices-openexchangerates has been updated to ensure compatibility with Django 5.
+
+Please note that while the maintainer of this fork will try to keep it updated, it is recommended to use the official package once it supports Django 5.
+
 ```python
 from prices import Money
 from django_prices_openexchangerates import exchange_currency

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     include_package_data=True,
     classifiers=CLASSIFIERS,
-    install_requires=["Django>=3.0", "django-prices>=1.0.0", "prices>=1.0.0"],
+    install_requires=["Django>=3.0", "django-prices>=2.3.0", "prices>=1.0.0"],
     platforms=["any"],
     tests_require=["mock==1.0.1", "pytest"],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     ],
     include_package_data=True,
     classifiers=CLASSIFIERS,
-    install_requires=["Django>=3.0", "django-prices>=2.3.0", "prices>=1.0.0"],
+    install_requires=["Django>=3.0", "django-prices @ "
+                                     "git+https://github.com/eboladuan/django-prices@django-5-support", "prices>=1.0.0"],
     platforms=["any"],
     tests_require=["mock==1.0.1", "pytest"],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     classifiers=CLASSIFIERS,
     install_requires=["Django>=3.0", "django-prices @ "
-                                     "git+https://github.com/eboladuan/django-prices@django-5-support", "prices>=1.0.0"],
+                                     "git+https://github.com/ebolasudan/django-prices@django-5-support", "prices>=1.0.0"],
     platforms=["any"],
     tests_require=["mock==1.0.1", "pytest"],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,17 @@
 [tox]
 envlist =
-    py37-django3
-    py{38,39,310,311,312}-django{3,4,5}
-    py{38,39,310,311,312}-django_master
+    # Django 3.x is compatible with Python 3.7 - 3.9
+    py{37,38,39}-django3
+
+    # Django 4.x is compatible with Python 3.8 - 3.11
+    py{38,39,310,311}-django4
+
+    # Django 5.x (pre-release) is compatible with Python 3.10 - 3.12
+    py{310,311,312}-django5
+
+    # Django master is likely compatible with the latest Python versions only (3.10+)
+    py{310,311,312}-django_master
+
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     py37-django3
-    py{38,39,310}-django{3,4}
-    py{38,39,310}-django_master
+    py{38,39,310,311,312}-django{3,4,5}
+    py{38,39,310,311,312}-django_master
 
 [gh-actions]
 python =
@@ -10,12 +10,15 @@ python =
      3.8: py38
      3.9: py39
      3.10: py310
+     3.11: py311
+     3.12: py312
 
 [testenv]
 pip_pre = true
 deps =
     django3: Django>=3.0,<4
     django4: Django>=4.0,<5
+    django5: Django>=5.0,<6
     pytest
     pytest-cov
     pytest-django
@@ -31,12 +34,15 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
 unignore_outcomes = True
 
 [travis:env]
 DJANGO =
     3: django3
     4: django4
+    5: django5
     master: django_master
 
 [pytest]


### PR DESCRIPTION
Updated tox.ini to include testing environments for Django 5 and Python versions 3.11 and 3.12. Updated README.md to reflect the new compatibility with Django 5.